### PR TITLE
feat: bake selected product versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,8 +14,8 @@ repos:
     hooks:
       - id: detect-secrets
         exclude: test/
-  - repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v2.0.1
+  - repo: https://github.com/hhatto/autopep8
+    rev: v2.0.4
     hooks:
       - id: autopep8
         entry: autopep8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+
+### Added
+
+- New `bake` command line option (`-v` or `--product-version`) to build a specific product version ([#1])
+
+[#1]: https://github.com/stackabletech/image-tools/pull/1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- New `bake` command line option (`-v` or `--product-version`) to build a specific product version ([#1])
+- New `bake` command line option `-v` (or `--product-version`) to build a specific product version ([#1])
+- New `bake` command line options `-q` (or `--product-version-quantile`) and `-m` (or `--max-bake-runners`) ([#1])
 
 [#1]: https://github.com/stackabletech/image-tools/pull/1

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Following tools are installed:
     bake -p opa -i 0.0.0-dev --product-version 0.37.2
 
     # Build half of all versions defined for OPA
-    bake -p opa -i 0.0.0-dev  --max-bake-runners 2 --product-version-quantile 0
+    bake -p opa -i 0.0.0-dev  --shard-count 2 --shard-index 0
 
     # Build the other half of all versions defined for OPA
-    bake -p opa -i 0.0.0-dev  --max-bake-runners 2 --product-version-quantile 1
+    bake -p opa -i 0.0.0-dev  --shard-count 2 --shard-index 1
 
     # Run preflight checks on the hello-world container images
     check-container -p hello-world -i 0.0.0-dev

--- a/README.md
+++ b/README.md
@@ -26,8 +26,18 @@ Following tools are installed:
 
 ## Examples
 
-    # Build images of the hello-world containers
-    bake -p hello-world -i 0.0.0-dev --organization sandbox
+    # Build all image versions of the hello-world product
+    bake -p hello-world -i 0.0.0-dev
+
+    # Build only one version [0.37.2] of OPA
+    bake -p opa -i 0.0.0-dev --product-version 0.37.2
+
+    # Build half of all versions defined for OPA
+    bake -p opa -i 0.0.0-dev  --max-bake-runners 2 --product-version-quantile 0
+
+    # Build the other half of all versions defined for OPA
+    bake -p opa -i 0.0.0-dev  --max-bake-runners 2 --product-version-quantile 1
+
     # Run preflight checks on the hello-world container images
     check-container -p hello-world -i 0.0.0-dev
 

--- a/src/image_tools/args.py
+++ b/src/image_tools/args.py
@@ -73,9 +73,9 @@ def bake_args() -> Namespace:
 
     result = parser.parse_args()
 
-    if result.product_version_quantile is not None and result.product_version_quantile >= result.max_bake_runners:
+    if result.shard_index is not None and result.shard_index >= result.shard_count:
         raise ValueError("product-version-quantile [{}] cannot be greater or equal than max-bake-runners [{}]".format(
-            result.product_version_quantile, result.max_bake_runners))
+            result.shard_index, result.shard_count))
     return result
 
 

--- a/src/image_tools/args.py
+++ b/src/image_tools/args.py
@@ -59,9 +59,8 @@ def bake_args() -> Namespace:
         help="Product version to bake."
     )
     parser.add_argument(
-        "-q",
-        "--product-version-quantile",
-        help="An int representing the n-th quantile of max-bake-runners.",
+        "--shard-index",
+        help="Build shard number M out of --shard-count. Shards are zero-indexed.",
         type=positive_int,
     )
     parser.add_argument(

--- a/src/image_tools/args.py
+++ b/src/image_tools/args.py
@@ -65,9 +65,8 @@ def bake_args() -> Namespace:
         type=positive_int,
     )
     parser.add_argument(
-        "-m",
-        "--max-bake-runners",
-        help="Max bake runners.",
+        "--shard-count",
+        help="Split the build into N shards, which can be built separately. All shards must be built separately, by specifying the --shard-index argument.",
         type=positive_int,
         default=1,
     )

--- a/src/image_tools/args.py
+++ b/src/image_tools/args.py
@@ -56,10 +56,40 @@ def bake_args() -> Namespace:
     parser.add_argument(
         "-v",
         "--product-version",
-        help="Product version to build."
+        help="Product version to bake."
+    )
+    parser.add_argument(
+        "-q",
+        "--product-version-quantile",
+        help="An int representing the n-th quantile of max-bake-runners.",
+        type=positive_int,
+    )
+    parser.add_argument(
+        "-m",
+        "--max-bake-runners",
+        help="Max bake runners.",
+        type=positive_int,
+        default=5,
     )
 
-    return parser.parse_args()
+    result = parser.parse_args()
+
+    if result.product_version_quantile is not None and result.product_version_quantile >= result.max_bake_runners:
+        raise ValueError("product-version-quantile [{}] cannot be greater or equal than max-bake-runners [{}]".format(
+            result.product_version_quantile, result.max_bake_runners))
+    return result
+
+
+def positive_int(value) -> int:
+    ivalue = 0
+    try:
+        ivalue = int(value)
+    except ValueError:
+        raise ValueError(f"Invalid value [{value}]. Must be an integer greater or equal to zero.")
+
+    if ivalue < 0:
+        raise ValueError("Invalid value [{value}]. Must be an integer greater or equal to zero.")
+    return ivalue
 
 
 def check_image_version_format(image_version) -> str:

--- a/src/image_tools/args.py
+++ b/src/image_tools/args.py
@@ -152,7 +152,7 @@ def check_architecture_input(architecture) -> List[str]:
     supported_arch = ["linux/amd64", "linux/arm64"]
 
     if architecture not in supported_arch:
-        msg=f"Architecture {architecture} not supported. Supported: {supported_arch}"
+        msg = f"Architecture {architecture} not supported. Supported: {supported_arch}"
         raise ValueError(msg)
 
     return architecture

--- a/src/image_tools/args.py
+++ b/src/image_tools/args.py
@@ -69,7 +69,7 @@ def bake_args() -> Namespace:
         "--max-bake-runners",
         help="Max bake runners.",
         type=positive_int,
-        default=5,
+        default=1,
     )
 
     result = parser.parse_args()

--- a/src/image_tools/args.py
+++ b/src/image_tools/args.py
@@ -53,6 +53,12 @@ def bake_args() -> Namespace:
         help="Image registry to publish to. Default: docker.stackable.tech",
         default="docker.stackable.tech",
     )
+    parser.add_argument(
+        "-v",
+        "--product-version",
+        help="Product version to build."
+    )
+
     return parser.parse_args()
 
 
@@ -146,9 +152,8 @@ def check_architecture_input(architecture) -> List[str]:
     supported_arch = ["linux/amd64", "linux/arm64"]
 
     if architecture not in supported_arch:
-        raise ValueError(
-            f"Architecture {architecture} not supported. Supported: {supported_arch}"
-        )
+        msg=f"Architecture {architecture} not supported. Supported: {supported_arch}"
+        raise ValueError(msg)
 
     return architecture
 

--- a/src/image_tools/args.py
+++ b/src/image_tools/args.py
@@ -86,7 +86,7 @@ def positive_int(value) -> int:
         raise ValueError(f"Invalid value [{value}]. Must be an integer greater or equal to zero.")
 
     if ivalue < 0:
-        raise ValueError("Invalid value [{value}]. Must be an integer greater or equal to zero.")
+        raise ValueError("Invalid value [{value}]. Must be an integer greater than or equal to zero.")
     return ivalue
 
 

--- a/src/image_tools/args.py
+++ b/src/image_tools/args.py
@@ -65,7 +65,8 @@ def bake_args() -> Namespace:
     )
     parser.add_argument(
         "--shard-count",
-        help="Split the build into N shards, which can be built separately. All shards must be built separately, by specifying the --shard-index argument.",
+        help="Split the build into N shards, which can be built separately. All shards must be built separately, \
+        by specifying the --shard-index argument.",
         type=positive_int,
         default=1,
     )
@@ -79,15 +80,14 @@ def bake_args() -> Namespace:
 
 
 def positive_int(value) -> int:
-    ivalue = 0
     try:
         ivalue = int(value)
+        if ivalue < 0:
+            raise ValueError
+        return ivalue
     except ValueError:
-        raise ValueError(f"Invalid value [{value}]. Must be an integer greater or equal to zero.")
-
-    if ivalue < 0:
-        raise ValueError("Invalid value [{value}]. Must be an integer greater than or equal to zero.")
-    return ivalue
+        raise ValueError(
+            f"Invalid value [{value}]. Must be an integer greater than or equal to zero.")
 
 
 def check_image_version_format(image_version) -> str:

--- a/src/image_tools/bake.py
+++ b/src/image_tools/bake.py
@@ -6,7 +6,6 @@ Usage:
 
     python -m image_tools.bake -p opa -i 22.12.0
 """
-import sys
 from typing import List, Dict, Any, Optional
 from argparse import Namespace
 from subprocess import run
@@ -208,12 +207,13 @@ def main():
 
     conf = load_configuration(args.configuration)
     filtered_product_version_count = filter_product_version(conf, args.product, args.product_version,
-                                                   args.product_version_quantile,
-                                                   args.max_bake_runners)
+                                                            args.product_version_quantile,
+                                                            args.max_bake_runners)
     if filtered_product_version_count is not None:
         if filtered_product_version_count == 0:
-            logging.info(f"Nothing to bake for product [{args.product}]. Exiting.")
-            sys.exit(0)
+            logging.info(
+                f"Nothing to bake for product [{args.product}]. Exiting.")
+            return
 
     bakefile = generate_bakefile(args, conf)
 

--- a/src/image_tools/bake.py
+++ b/src/image_tools/bake.py
@@ -192,7 +192,8 @@ def filter_product_version(conf, product_name: Optional[str], product_version: O
 
 def bake_product_version(version: str, version_index: int, product_version: Optional[str],
                          product_version_quantile: Optional[int], max_bake_runners: int) -> bool:
-    """ Return True if `version` equals `product_version` of if it falls in the quantile specified by `product_version_quantile`
+    """ Return True if `version` equals `product_version` of if it falls in the quantile specified
+        by `product_version_quantile`
     """
     if product_version and version == product_version:
         return True

--- a/src/image_tools/bake.py
+++ b/src/image_tools/bake.py
@@ -174,9 +174,6 @@ def filter_product_version(conf, product_name: Optional[str], product_version: O
                     if bake_product_version(version_dict["product"], index, product_version, product_version_quantile,
                                             max_bake_runners):
                         filtered_product_versions.append(version_dict)
-                # Stop early
-                #if not len(filtered_product_versions):
-                #    logging.info(f"No version to build for product {product_name}")
                 # Make a copy of the product and replace the "versions" array with the version that matched.
                 filtered_product = product
                 filtered_product["versions"] = filtered_product_versions
@@ -187,7 +184,7 @@ def filter_product_version(conf, product_name: Optional[str], product_version: O
             else:
                 filtered_products.append(product)
         conf.products = filtered_products
-        return result
+    return result
 
 
 def bake_product_version(version: str, version_index: int, product_version: Optional[str],


### PR DESCRIPTION
Allow baking a specific product version or a subset of versions. The latter is useful for parallelizing builds on GH runners.

See README for examples.