### PR TITLE
fix: add platform argument to preflight calls

### DIFF
--- a/src/image_tools/args.py
+++ b/src/image_tools/args.py
@@ -132,7 +132,6 @@ def preflight_args() -> Namespace:
         "-a",
         "--architecture",
         help="Target platform for image. Default: linux/amd64.",
-        nargs="+",
         default="linux/amd64",
         type=check_architecture_input,
     )

--- a/src/image_tools/args.py
+++ b/src/image_tools/args.py
@@ -43,7 +43,7 @@ def bake_args() -> Namespace:
         "--architecture",
         help="Target platform for image. Default: linux/amd64.",
         nargs="+",
-        default=["linux/amd64"],
+        default="linux/amd64",
         type=check_architecture_input,
     )
     parser.add_argument(
@@ -133,7 +133,7 @@ def preflight_args() -> Namespace:
         "--architecture",
         help="Target platform for image. Default: linux/amd64.",
         nargs="+",
-        default=["linux/amd64"],
+        default="linux/amd64",
         type=check_architecture_input,
     )
     parser.add_argument(
@@ -174,7 +174,7 @@ def preflight_args() -> Namespace:
     return result
 
 
-def check_architecture_input(architecture) -> List[str]:
+def check_architecture_input(architecture: str) -> str:
     supported_arch = ["linux/amd64", "linux/arm64"]
 
     if architecture not in supported_arch:

--- a/src/image_tools/preflight.py
+++ b/src/image_tools/preflight.py
@@ -74,7 +74,9 @@ def preflight_commands(images: List[str], args: Namespace, conf) -> Dict[str, Co
         if args.architecture:
             cmd_args.extend(
                 ["--platform",
-                    args.architecture,
+                    # this argument value has already been checked against valid values with an expected prefix.
+                    # Preflight provides the same "linux/" prefix and so it must be removed here.
+                    args.architecture.split("linux/")[1],
                  ]
             )
         result[img] = Command(args=cmd_args)

--- a/src/image_tools/preflight.py
+++ b/src/image_tools/preflight.py
@@ -71,6 +71,12 @@ def preflight_commands(images: List[str], args: Namespace, conf) -> Dict[str, Co
                     f"ospid-{conf.open_shift_projects[args.product]['id']}",
                  ]
             )
+        if args.architecture:
+            cmd_args.extend(
+                ["--platform",
+                    args.architecture[0],
+                 ]
+            )
         result[img] = Command(args=cmd_args)
     return result
 

--- a/src/image_tools/preflight.py
+++ b/src/image_tools/preflight.py
@@ -74,7 +74,7 @@ def preflight_commands(images: List[str], args: Namespace, conf) -> Dict[str, Co
         if args.architecture:
             cmd_args.extend(
                 ["--platform",
-                    args.architecture[0],
+                    args.architecture,
                  ]
             )
         result[img] = Command(args=cmd_args)


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/559.

The architecture is checked when the arguments are parsed, but preflight ignores the value unless the image points to a manifest list, in which case the correct image is selected.

Only stackable-experimental contains manifest lists at the moment, so these calls will always result in the default (presumably fo the calling environment) being fetched:

`check-container -i 24.3.0 -p hive -a linux/amd64` --> amd64 image
`check-container -i 24.3.0 -p hive -a linux/arm64` --> amd64 image

`preflight .../stackable/hive:3.1.3-stackable24.3.0 --platform linux/amd64` --> amd64 image
`preflight .../stackable/hive:3.1.3-stackable24.3.0 --platform linux/arm64` --> amd64 image

Preflight seems to provide the prefix so this is removed before passing the command off to preflight:

`preflight .../stackable-experimental/hive:3.1.3-stackable24.3.0 --platform linux/amd64` --> no child with platform linux/linux/amd64
`preflight .../stackable-experimental/hive:3.1.3-stackable24.3.0 --platform linux/arm64` --> no child with platform linux/linux/arm64

When pointing at a manifest list, the correct images are selected:

`preflight .../stackable-experimental/hive:3.1.3-stackable24.3.0 --platform amd64` --> amd64 image
`preflight .../stackable-experimental/hive:3.1.3-stackable24.3.0 --platform arm64` --> **arm64** image
