### PR TITLE
fix: use cwd in module path so imports in conf.py work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,12 @@ All notable changes to this project will be documented in this file.
 - Raise lint dependency versions ([#17])
 - Drop support for python 3.10 and add explicit support for 3.12 ([#17])
 
-[#17]: https://github.com/stackabletech/image-tools/pull/17
+### Fixed
 
+- Use cwd in module path so imports in conf.py work ([#27])
+
+[#17]: https://github.com/stackabletech/image-tools/pull/17
+[#27]: https://github.com/stackabletech/image-tools/pull/27
 
 ## 0.0.7
 

--- a/src/image_tools/args.py
+++ b/src/image_tools/args.py
@@ -3,6 +3,7 @@ from argparse import Namespace, ArgumentParser
 import re
 import importlib.util
 import sys
+import os
 
 from .version import version
 
@@ -206,6 +207,7 @@ def check_architecture_input(architecture: str) -> str:
 
 def load_configuration(conf_file_name: str):
     module_name = "conf"
+    sys.path.append(str(os.getcwd()))
     spec = importlib.util.spec_from_file_location(module_name, conf_file_name)
     if spec:
         module = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
Fixes `ModuleNotFoundError` when trying to import other modules in conf.py:

```py
import product1.versions as product1
import product2.versions as product2

products = [
    {
        "name": "product1",
        "versions": product1.versions,
    },
    {
        "name": "product2",
        "versions": product2.versions,
    },
]
```

The following error was being thrown:

```
Traceback (most recent call last):
  File "/home/runner/.local/bin/bake", line 8, in <module>
    sys.exit(main())
  File "/home/runner/.local/lib/python3.10/site-packages/image_tools/bake.py", line 173, in main
    conf = load_configuration(args.configuration)
  File "/home/runner/.local/lib/python3.10/site-packages/image_tools/args.py", line 195, in load_configuration
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/runner/work/dummy-docker-images/dummy-docker-images/./conf.py", line 7, in <module>
    import product1.versions as product1
ModuleNotFoundError: No module named 'product1'
```