### PR TITLE
feat(bake): new --build-arg cli parameter overrides conf.py properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- New `bake` command line argument `--build-arg` to override conf.py build arguments ([#38])
+
+[#38]: https://github.com/stackabletech/image-tools/pull/38
+
+
 ## [0.0.11]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,6 +15,35 @@ The `bake` command provides the following features:
 * Use one or more distributed docker cache servers
 * Publish images
 
+## Docker Build Cache
+
+Docker's `buildx` plugin supports different types of build cache back ends. Since Stackable product images are built by distributed GitHub actions, the distributed back ends are relevant.
+
+To use the build cache, you have to configure one or more back ends and enable them by calling `bake` with the `--cache` flag.
+
+To configure one or more cache back ends, add the relevant properties to the `cache` property of the configuration module.
+
+Here an example with the `registry` backend:
+
+```python
+cache = [
+    {
+        "type": "registry",
+        "ref_prefix": "build-repo.stackable.tech:8083/sandbox/cache",
+        "mode": "max",
+        "compression": "zstd",
+        "ignore-error": "true",
+    },
+]
+```
+
+Here `ref_prefix` is used to build the unique `ref` property for each target.
+
+NOTE: it's your responsibility to ensure that `bake` can read/write to the cache registry by performing a `docker login` before running `bake`.
+
+
+For more information about the cache back ends, see the [Docker documentation](https://docs.docker.com/build/cache/backends/).
+
 ## Usage examples
 
 Run either `bake` or `check-container` with `--help` to get an overview of the accepted flags and their functionality.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ bake --product opa --cache
 
 # Build the HBase images but use Java 21 instead of the values in conf.py
 # for the java-base and java-devel images.
-# It doesn't matter if you use lower or upper case for the build argument names.
+# It doesn't matter if you use lower or upper case for the build argument names,
+# bake will normalize all of them to upper case.
 bake --product hbase --build-arg 'java-base=21' --build-arg 'java-devel=21'
 
 # Build half of all versions defined for OPA

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ bake --product opa --cache
 
 # Build the HBase images but use Java 21 instead of the values in conf.py
 # for the java-base and java-devel images.
+# It doesn't matter if you use lower or upper case for the build argument names.
 bake --product hbase --build-arg 'java-base=21' --build-arg 'java-devel=21'
 
 # Build half of all versions defined for OPA

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ bake --product hello-world
 # Build only one version [0.37.2] of OPA
 bake --product opa=0.37.2
 
-# Dry run. Do not buikd anything. Print the the generated Bakefile.
+# Dry run. Do not build anything. Print the the generated Bakefile.
 bake --product hello-world --dry
 
 # Build all OPA images and set the organisation to "sandbox"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ bake --product opa=0.37.2
 bake --product hello-world --dry
 
 # Build all OPA images and set the organisation to "sandbox"
-bake --product opa=0.37.2 --organization sandbox
+bake --product opa --organization sandbox
 
 # Build all OPA images and set the image version to a release 24.7.0
 bake --product opa --image-version 24.7.0

--- a/README.md
+++ b/README.md
@@ -22,19 +22,32 @@ Below are some common usage examples:
 
 ```shell
 # Build images of the hello-world containers
-bake -p hello-world -i 0.0.0-dev
+bake --product hello-world
 
 # Build only one version [0.37.2] of OPA
-bake -p opa=0.37.2 -i 0.0.0-dev
+bake --product opa=0.37.2
+
+# Dry run. Do not buikd anything. Print the the generated Bakefile.
+bake --product hello-world --dry
+
+# Build all OPA images and set the organisation to "sandbox"
+bake --product opa=0.37.2 --organization sandbox
+
+# Build all OPA images and set the image version to a release 24.7.0
+bake --product opa --image-version 24.7.0
 
 # Enable distributed docker cache (requires credentials to access the cache registry)
-bake -p opa --cache
+bake --product opa --cache
+
+# Build the HBase images but use Java 21 instead of the values in conf.py
+# for the java-base and java-devel images.
+bake --product hbase --build-arg 'java-base=21' --build-arg 'java-devel=21'
 
 # Build half of all versions defined for OPA
-bake -p opa -i 0.0.0-dev  --shard-count 2 --shard-index 0
+bake --product opa --shard-count 2 --shard-index 0
 
 # Build the other half of all versions defined for OPA
-bake -p opa -i 0.0.0-dev  --shard-count 2 --shard-index 1
+bake --product opa --shard-count 2 --shard-index 1
 ```
 
 ## Installation
@@ -63,8 +76,8 @@ let
   image-tools = pkgs.callPackage (pkgs.fetchFromGitHub {
     owner = "stackabletech";
     repo = "image-tools";
-    rev = "caa4d993bcbb8b884097c89a54ee246f975e2ec6";
-    hash = "sha256-gjTCroHw4iJhXPW+s3mHBzIH8seIKH1tPb82lUb8+a0="; # comment out to find new hashes when upgrading
+    rev = "caa4d993bcbb8b884097c89a54ee246f975e2ec6"; # pragma: allowlist secret
+    hash = "sha256-gjTCroHw4iJhXPW+s3mHBzIH8seIKH1tPb82lUb8+a0="; # pragma: allowlist secret ; comment out to find new hashes when upgrading
   } + "/image-tools.nix") {};
 in
 {
@@ -96,6 +109,19 @@ pipx install --editable .
 ```
 
 With the activated virtual environment, you can now run the tools from the `docker-images` repository and any local changes are immediately in effect.
+
+We also recommend installing the `pre-commit` hooks in the activated virtual environment.
+
+```shell
+pip install pre-commit
+pre-commit install
+```
+
+To run the hooks, stage the changes you want to commit and run:
+
+```shell
+pre-commit run
+```
 
 ## Release a new version
 

--- a/src/image_tools/args.py
+++ b/src/image_tools/args.py
@@ -4,6 +4,8 @@ import re
 import importlib.util
 import sys
 import os
+from types import ModuleType
+from typing import List, Tuple
 
 from .version import version
 
@@ -20,14 +22,13 @@ def bake_args() -> Namespace:
     )
     parser.add_argument("-v", "--version", help="Display version", action="store_true")
 
-    (
-        parser.add_argument(
-            "-c",
-            "--configuration",
-            help="Configuration file. Default: './conf.py'.",
-            default="./conf.py",
-        ),
+    parser.add_argument(
+        "-c",
+        "--configuration",
+        help="Configuration file. Default: './conf.py'.",
+        default="./conf.py",
     )
+
     parser.add_argument(
         "-i",
         "--image-version",
@@ -75,13 +76,19 @@ def bake_args() -> Namespace:
         help="Image registry to publish to. Default: docker.stackable.tech.",
         default="docker.stackable.tech",
     )
-    (
-        parser.add_argument(
-            "--export-tags-file",
-            help="Write target image tags to a text file. Useful for signing or other follow-up CI steps.",
-        ),
+    parser.add_argument(
+        "--export-tags-file",
+        help="Write target image tags to a text file. Useful for signing or other follow-up CI steps.",
     )
-    (parser.add_argument("--cache", help="Enable distributed build cache", action="store_true"),)
+
+    parser.add_argument("--cache", help="Enable distributed build cache", action="store_true")
+
+    parser.add_argument(
+        "--build-arg",
+        help="Override build arguments. Expecting an ARGV=VALUE format.",
+        nargs="*",
+        type=check_build_arg,
+    )
 
     result = parser.parse_args()
 
@@ -133,6 +140,13 @@ def check_image_version_format(image_version) -> str:
     raise ValueError(f"Invalid image version: {image_version}")
 
 
+def check_build_arg(build_args: str) -> Tuple[str, str]:
+    kv = build_args.split("=")
+    if len(kv) != 2:
+        raise ValueError
+    return kv[0], kv[1]
+
+
 def preflight_args() -> Namespace:
     parser = ArgumentParser(
         description="Run OpenShift certification checks and submit results to RedHat Partner Connect portal"
@@ -180,13 +194,11 @@ def preflight_args() -> Namespace:
         help="Name of the preflight program. Default: preflight",
         default="preflight",
     )
-    (
-        parser.add_argument(
-            "-c",
-            "--configuration",
-            help="Configuration file.",
-            default="./conf.py",
-        ),
+    parser.add_argument(
+        "-c",
+        "--configuration",
+        help="Configuration file.",
+        default="./conf.py",
     )
 
     result = parser.parse_args()
@@ -206,7 +218,11 @@ def check_architecture_input(architecture: str) -> str:
     return architecture
 
 
-def load_configuration(conf_file_name: str):
+def load_configuration(conf_file_name: str, user_build_args: List[Tuple[str, str]] = []) -> ModuleType:
+    """Load the configuration module conf.py and potentially override build arguments
+    with values provided by the user with the --build-arg flag.
+    The build arguments are key, value pairs from the "conf.products.<product name>.versions.<version>" dictionary.
+    """
     module_name = "conf"
     sys.path.append(str(os.getcwd()))
     spec = importlib.util.spec_from_file_location(module_name, conf_file_name)
@@ -215,5 +231,18 @@ def load_configuration(conf_file_name: str):
         sys.modules[module_name] = module
         if spec.loader:
             spec.loader.exec_module(module)
+            override_build_args(module, user_build_args)
             return module
     raise ImportError(name=module_name, path=conf_file_name)
+
+
+def override_build_args(conf: ModuleType, user_build_args: List[Tuple[str, str]] = []) -> None:
+    if not user_build_args:
+        return
+    # convert user_build_args to a dictionary for easier lookup
+    user_build_args_dict = {kv[0]: kv[1] for kv in user_build_args}
+    for product in conf.products:
+        for conf_build_args in product["versions"]:
+            for arg in conf_build_args:
+                if arg in user_build_args_dict:
+                    conf_build_args[arg] = user_build_args_dict[arg]

--- a/src/image_tools/args.py
+++ b/src/image_tools/args.py
@@ -85,7 +85,7 @@ def bake_args() -> Namespace:
 
     parser.add_argument(
         "--build-arg",
-        help="Override build arguments. Expecting an ARGV=VALUE format.",
+        help="Override build arguments. Expecting an KEY=VALUE format. The key is case insensitive.",
         nargs="*",
         type=check_build_arg,
     )

--- a/src/image_tools/bake.py
+++ b/src/image_tools/bake.py
@@ -22,7 +22,7 @@ from .lib import Command
 from .version import version
 
 
-def build_image_args(version: Dict[str, str], release_version: str):
+def build_image_args(conf_build_args: Dict[str, str], release_version: str):
     """
     Returns a list of --build-arg command line arguments that are used by the
     docker build command.
@@ -33,7 +33,7 @@ def build_image_args(version: Dict[str, str], release_version: str):
     """
     result = {}
 
-    for k, v in version.items():
+    for k, v in conf_build_args.items():
         result[k.upper()] = v
     result["RELEASE"] = release_version
 
@@ -213,7 +213,7 @@ def main() -> int:
         print(version())
         return 0
 
-    conf = load_configuration(args.configuration)
+    conf = load_configuration(args.configuration, args.build_arg)
 
     bakefile = generate_bakefile(args, conf)
 


### PR DESCRIPTION
Use --build-arg to easily experiment with Docker build arguments without modifying conf.py. See README for an example.

Main purpose will be to enable Maven repository reuse when building Docker images locally. This should significantly speed up the build process (locally).