### PR TITLE
feat: Add --target-containerfile argument

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,4 +63,4 @@ repos:
         language: python
         'types': [python]
         pass_filenames: false
-        stages: [commit]
+        stages: [pre-commit]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,12 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- `conf.py` now can contain a `args` dict, which contains arguments available to all products, they can be overridden by product specific or CLI arguments ([#41])
+- `conf.py` now can contain a `args` dict, which contains arguments available to all products, they
+  can be overridden by product specific or CLI arguments ([#41]).
 
 ### Fixed
 
-- `--build-arg` was not case-insensitive as claimed in the docs, this has been  fixed ([#41])
+- `--build-arg` was not case-insensitive as claimed in the docs, this has been  fixed ([#41]).
 
 [#41]: https://github.com/stackabletech/image-tools/pull/41
 
@@ -26,11 +27,11 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- New `bake` command line argument `--build-arg` to override conf.py build arguments ([#38])
+- New `bake` command line argument `--build-arg` to override conf.py build arguments ([#38]).
 
 ### Fixed
 
-- check-container: fix regression introduced by 0.0.9. Add dummy cache property ([#39])
+- check-container: fix regression introduced by 0.0.9. Add dummy cache property ([#39]).
 
 [#38]: https://github.com/stackabletech/image-tools/pull/38
 [#39]: https://github.com/stackabletech/image-tools/pull/39
@@ -39,7 +40,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Automatically create labels and annotations recording the git revision and build time ([#34])
+- Automatically create labels and annotations recording the git revision and build time ([#34]).
 
 [#34]: https://github.com/stackabletech/image-tools/pull/34
 
@@ -47,8 +48,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Add architecture identifier to the build cache backend ref name ([#31])
-- Backwards compat: don't assume conf.cache exists ([#32])
+- Add architecture identifier to the build cache backend ref name ([#31]).
+- Backwards compat: don't assume conf.cache exists ([#32]).
 
 [#31]: https://github.com/stackabletech/image-tools/pull/31
 [#32]: https://github.com/stackabletech/image-tools/pull/32
@@ -57,7 +58,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- New command line arg to `bake`: `--cache`. Requires cache backend configuration in conf.py ([#29])
+- New command line arg to `bake`: `--cache`. Requires cache backend configuration in
+  `conf.py` ([#29]).
 
 [#29]: https://github.com/stackabletech/image-tools/pull/29
 
@@ -65,13 +67,13 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- New command line arg to `bake`: `--version`. Also switch to relative imports. ([#17])
-- Raise lint dependency versions ([#17])
-- Drop support for python 3.10 and add explicit support for 3.12 ([#17])
+- New command line arg to `bake`: `--version`. Also switch to relative imports ([#17]).
+- Raise lint dependency versions ([#17]).
+- Drop support for python 3.10 and add explicit support for 3.12 ([#17]).
 
 ### Fixed
 
-- Use cwd in module path so imports in conf.py work ([#27])
+- Use cwd in module path so imports in `conf.py` work ([#27]).
 
 [#17]: https://github.com/stackabletech/image-tools/pull/17
 [#27]: https://github.com/stackabletech/image-tools/pull/27
@@ -80,7 +82,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Invalid 'buildx bake' configuration file generated due to architecture not being a list anymore. ([#13])
+- Invalid 'buildx bake' configuration file generated due to architecture not being a list
+  anymore ([#13]).
 
 [#13]: https://github.com/stackabletech/image-tools/pull/13
 
@@ -88,7 +91,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Add platform argument for preflight checks ([#12])
+- Add platform argument for preflight checks ([#12]).
 
 [#12]: https://github.com/stackabletech/image-tools/pull/12
 
@@ -96,7 +99,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Relax schema for image tags ([#7])
+- Relax schema for image tags ([#7]).
 
 [#7]: https://github.com/stackabletech/image-tools/pull/7
 
@@ -104,11 +107,11 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- New `bake` argument (`--export-tags-file`) to write target tags to text file ([#4])
+- New `bake` argument (`--export-tags-file`) to write target tags to text file ([#4]).
 
 ### Changed
 
-- Changed `conf` schema to drop support for versions as strings. Only dicts are supported ([#4])
+- Changed `conf` schema to drop support for versions as strings. Only dicts are supported ([#4]).
 
 [#4]: https://github.com/stackabletech/image-tools/pull/4
 
@@ -116,11 +119,11 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Allow `bake` product names to accept a version as suffix separated by "=" ([#2])
-- New `bake` command line options `--shard-index` and `--shard-count` ([#2])
+- Allow `bake` product names to accept a version as suffix separated by "=" ([#2]).
+- New `bake` command line options `--shard-index` and `--shard-count` ([#2]).
 
 ### Changed
 
-- Make stackable image version (`-i`) for `bake` optional and default to `0.0.0-dev` ([#2])
+- Make stackable image version (`-i`) for `bake` optional and default to `0.0.0-dev` ([#2]).
 
 [#2]: https://github.com/stackabletech/image-tools/pull/2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## Added
+
+- Add `--target-containerfile` argument to override the default `Dockerfile` value ([#44]).
+
+[#44]: https://github.com/stackabletech/image-tools/pull/44
+
 ## 0.0.13 - 2024-09-06
 
 ### Added

--- a/src/image_tools/args.py
+++ b/src/image_tools/args.py
@@ -90,6 +90,12 @@ def bake_args() -> Namespace:
         type=check_build_arg,
     )
 
+    parser.add_argument(
+        "--target-containerfile",
+        help="Override the target containerfile used, points to <PRODUCT>/<TARGET_CONTAINERFILE>. Default: Dockerfile",
+        default="Dockerfile",
+    )
+
     result = parser.parse_args()
 
     if result.shard_index >= result.shard_count:
@@ -238,6 +244,7 @@ def load_configuration(conf_file_name: str, cli_build_args: List[Tuple[str, str]
             assemble_final_build_args(module, cli_build_args)
             return module
     raise ImportError(name=module_name, path=conf_file_name)
+
 
 def assemble_final_build_args(conf: ModuleType, cli_build_args: List[Tuple[str, str]] = []) -> None:
     cli_build_args = cli_build_args or []

--- a/src/image_tools/bake.py
+++ b/src/image_tools/bake.py
@@ -122,7 +122,7 @@ def bakefile_product_version_targets(
                 "build-date": rfc3339_date_time,
                 "org.opencontainers.image.revision": revision,
             },
-            "dockerfile": f"{product_name}/Dockerfile",
+            "dockerfile": f"{product_name}/{args.target_containerfile}",
             "tags": tags,
             "args": build_args,
             "platforms": [args.architecture],


### PR DESCRIPTION
This PR adds the ability to customize the target containerfile used, defaults to `Dockerfile`. This for example allows the use of `Containerfile` instead of the currently hardcoded `Dockerfile`.