### PR TITLE
feat: support for Dockerfiles in subdirectories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Add support for bake target hierarchies ([#51])
+
+[#51]: https://github.com/stackabletech/image-tools/pull/51
+
 ## [0.0.14] - 2025-02-04
 
 ### Added

--- a/src/image_tools/bake.py
+++ b/src/image_tools/bake.py
@@ -62,7 +62,7 @@ def build_image_tags(image_name: str, image_version: str, product_version: str) 
 
 def generate_bakefile(args: Namespace, conf) -> Dict[str, Any]:
     """
-    Generates a Bakefile (https://docs.docker.com/build/bake/file-definition/) describing how to build the image graph.
+    Generates a Bakefile (see https://docs.docker.com/build/bake/reference) describing how to build the image graph.
 
     build_and_publish_images() ensures that only the desired images are actually built.
     """

--- a/src/image_tools/bake.py
+++ b/src/image_tools/bake.py
@@ -44,7 +44,7 @@ def build_image_args(conf_build_args: Dict[str, str], release_version: str):
     result = {}
 
     for k, v in conf_build_args.items():
-        result[k.upper()] = v
+        result[k.replace("-", "_").replace("/", "_").upper()] = v
     result["RELEASE"] = release_version
 
     return result
@@ -81,7 +81,7 @@ def generate_bakefile(args: Namespace, conf) -> Dict[str, Any]:
             product_targets.update(
                 bakefile_product_version_targets(args, product_name, version_dict, product_names, build_cache)
             )
-        groups[product_name] = {
+        groups[product_name.replace("/", "_")] = {
             "targets": list(product_targets.keys()),
         }
         targets.update(product_targets)
@@ -98,7 +98,7 @@ def bakefile_target_name_for_product_version(product_name: str, version: str) ->
     """
     Creates a normalized Bakefile target name for a given (product, version) combination.
     """
-    return f"{product_name}-{version.replace('.', '_')}"
+    return f"{product_name.replace('/', '_')}-{version.replace('.', '_')}"
 
 
 def bakefile_product_version_targets(


### PR DESCRIPTION
Needed for https://github.com/stackabletech/docker-images/issues/1067

We want to modularize the Dockerfiles: Components like `hbase-operator-tools` or `phoenix` should have their own Dockerfiles, instead of being included in the one for HBase.
Currently, `bake` expects the Dockerfile to be in `f"{product_name}/{args.target_containerfile}"`, which is fine. But for Dockerfiles located in subdirectories we need to allow slashes in product names. They are allowed in general and work fine, just not in target names (`Invalid name; only "[a-zA-Z0-9_-]+" are allowed`). That's why this PR replaces slashes with underscores (similar to the dots in versions).

A similar thing is done for build arguments, so `hbase/hbase-operator-tools` will become the argument `HBASE_HBASE_OPERATOR_TOOLS`. While `HBASE/HBASE-OPERATOR-TOOLS` would technically work as a build argument, bash variable names only support letters, numbers and underscores.

The change should be backwards compatible for us since we currently don't use slashes or hyphens in our build arguments.