### PR TITLE
feat: separate --release argument for SDP version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - Add support for bake target hierarchies ([#51])
+- Add a separate `--release` argument for the SDP version ([#55])
 
 [#51]: https://github.com/stackabletech/image-tools/pull/51
+[#55]: https://github.com/stackabletech/image-tools/pull/55
 
 ## [0.0.14] - 2025-02-04
 

--- a/src/image_tools/args.py
+++ b/src/image_tools/args.py
@@ -15,6 +15,11 @@ DEFAULT_IMAGE_VERSION_FORMATS = [
     re.compile(r"0\.0\.0-dev(-.+)?"),
 ]
 
+DEFAULT_RELEASE_FORMATS = [
+    re.compile(r"[2-9][0-9]\.[1-9][0-2]?\.\d+(-rc\d+)?"),
+    re.compile(r"0\.0\.0-dev"),
+]
+
 
 def build_bake_argparser() -> ArgumentParser:
     parser = ArgumentParser(
@@ -35,6 +40,12 @@ def build_bake_argparser() -> ArgumentParser:
         type=check_image_version_format,
         default="0.0.0-dev",
         help="Image version. Default: 0.0.0-dev.",
+    )
+    parser.add_argument(
+        "--release",
+        type=check_release_format,
+        default="0.0.0-dev",
+        help="SDP release version. Default: 0.0.0-dev.",
     )
     parser.add_argument(
         "-p",
@@ -164,6 +175,43 @@ def check_image_version_format(image_version) -> str:
     raise ValueError(f"Invalid image version: {image_version}")
 
 
+def check_release_format(release) -> str:
+    """
+        Check release against allowed formats.
+
+    >>> check_release_format("23.4.0")
+    '23.4.0'
+    >>> check_release_format("23.4.0-rc1")
+    '23.4.0-rc1'
+    >>> check_release_format("0.0.0-dev")
+    '0.0.0-dev'
+    >>> check_release_format("0.0.0-dev-kebab")
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+      File "<stdin>", line 5, in check_release_format
+    ValueError: Invalid release: 0.0.0-dev-kebab
+    >>> check_release_format("23.11.1-dev-kaese")
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+      File "<stdin>", line 5, in check_release_format
+    ValueError: Invalid release: 23.11.1-dev-kaese
+    >>> check_release_format("23.04.0")
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+      File "<stdin>", line 5, in check_release_format
+    ValueError: Invalid release: 23.04.0
+    >>> check_release_format("23.4.0.prerelease")
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+      File "<stdin>", line 5, in check_release_format
+    ValueError: Invalid release: 23.4.0.prerelease
+    """
+    for p in DEFAULT_RELEASE_FORMATS:
+        if p.fullmatch(release):
+            return release
+    raise ValueError(f"Invalid release: {release}")
+
+
 def check_build_arg(build_args: str) -> Tuple[str, str]:
     kv = build_args.split("=")
     if len(kv) != 2:
@@ -181,9 +229,16 @@ def preflight_args() -> Namespace:
     parser.add_argument(
         "-i",
         "--image-version",
-        help="Image version",
+        help="Image version. Default: 0.0.0-dev.",
         required=True,
         type=check_image_version_format,
+    )
+
+    parser.add_argument(
+        "--release",
+        help="SDP release version. Default: 0.0.0-dev.",
+        required=True,
+        type=check_release_format,
     )
     parser.add_argument("-p", "--product", help="Product to build images for", required=True)
     parser.add_argument("-s", "--submit", help="Submit results", action="store_true")

--- a/src/image_tools/args.py
+++ b/src/image_tools/args.py
@@ -229,7 +229,7 @@ def preflight_args() -> Namespace:
     parser.add_argument(
         "-i",
         "--image-version",
-        help="Image version. Default: 0.0.0-dev.",
+        help="Image version.",
         required=True,
         type=check_image_version_format,
     )

--- a/src/image_tools/args.py
+++ b/src/image_tools/args.py
@@ -233,13 +233,6 @@ def preflight_args() -> Namespace:
         required=True,
         type=check_image_version_format,
     )
-
-    parser.add_argument(
-        "--release",
-        help="SDP release version. Default: 0.0.0-dev.",
-        required=True,
-        type=check_release_format,
-    )
     parser.add_argument("-p", "--product", help="Product to build images for", required=True)
     parser.add_argument("-s", "--submit", help="Submit results", action="store_true")
     parser.add_argument("-d", "--dry", help="Dry run.", action="store_true")

--- a/src/image_tools/bake.py
+++ b/src/image_tools/bake.py
@@ -115,7 +115,7 @@ def bakefile_product_version_targets(
     """
     image_name = f"{args.registry}/{args.organization}/{product_name}"
     tags = build_image_tags(image_name, args.image_version, versions["product"])
-    build_args = build_image_args(versions, args.image_version)
+    build_args = build_image_args(versions, args.release)
     target_name = bakefile_target_name_for_product_version(product_name, versions["product"])
     rfc3339_date_time = datetime.now(timezone.utc).isoformat()
     revision = get_git_revision()


### PR DESCRIPTION
As discussed, we need a separate argument for the SDP version because we want to include the architecture in the image tag (`0.0.0-dev-amd64`) but not in the `RELEASE` argument.

I tested the change by replacing the Zookeeper Dockerfile with this:
```
FROM stackable/image/java-base

ARG RELEASE
RUN <<EOF
echo "RELEASE: ${RELEASE}"
sleep 5
EOF
```

And then ran a few tests:

```
bake -p zookeeper=3.9.3 -i 0.0.0-dev-amd64
bake -p zookeeper=3.9.3 -i 0.0.0-dev-amd64 --release 0.0.0-dev
bake -p zookeeper=3.9.3 -i 0.0.0-dev-amd64 --release 0.0.0-dev-bar
bake -p zookeeper=3.9.3 -i 0.0.0-dev-amd64 --release 25.3.0
bake -p zookeeper=3.9.3 -i 0.0.0-dev-amd64 --release 25.3.0-foo
bake -p zookeeper=3.9.3 -i 0.0.0-dev-amd64 --release 25.3.0-rc13
bake -p zookeeper=3.9.3 -i 0.0.0-dev-amd64 --release 25.3.0-amd64
```